### PR TITLE
Fix lifetime issue for PrettyParser::bundle and PrettyParser2d::bundle

### DIFF
--- a/crates/bevy_pretty_text/src/parser.rs
+++ b/crates/bevy_pretty_text/src/parser.rs
@@ -287,7 +287,7 @@ pub struct PrettyParser;
 impl PrettyParser {
     /// Parse `pretty_text` into a bundle.
     #[track_caller]
-    pub fn bundle(pretty_text: &str) -> Result<impl Bundle, PrettyParserError> {
+    pub fn bundle<'a>(pretty_text: &str) -> Result<impl Bundle + use<'a>, PrettyParserError> {
         Self::spans(pretty_text).map(ParsedPrettyText::into_bundle)
     }
 
@@ -332,7 +332,7 @@ pub struct PrettyParser2d;
 impl PrettyParser2d {
     /// Parse `pretty_text` into a bundle.
     #[track_caller]
-    pub fn bundle(pretty_text: &str) -> Result<impl Bundle, PrettyParserError> {
+    pub fn bundle<'a>(pretty_text: &str) -> Result<impl Bundle + use<'a>, PrettyParserError> {
         Self::spans(pretty_text).map(ParsedPrettyText::into_bundle)
     }
 


### PR DESCRIPTION
I was struggling to use `PrettyParser::bundle` in a wrapping bundle function like so:

```rust
use bevy::prelude::*;
use bevy_pretty_text::parser::PrettyParser;

pub fn text(text: String) -> impl Bundle {
    PrettyParser::bundle(&text).expect("invalid syntax")
}
```

This results in the following compile error:

```
error[E0597]: `text` does not live long enough
   --> src/ui/widgets/text.rs:5:26
    |
  4 | pub fn text(text: String) -> impl Bundle {
    |             ---- binding `text` declared here
  5 |     PrettyParser::bundle(&text).expect("invalid syntax")
    |     ---------------------^^^^^--------------------------
    |     |                    |
    |     |                    borrowed value does not live long enough
    |     argument requires that `text` is borrowed for `'static`
  6 | }
    | - `text` dropped here while still borrowed
    |
note: this call may capture more lifetimes than intended, because Rust 2024 has adjusted the `impl Trait` lifetime capture rules
```

I managed to fix this by adding `+ use<'a>` to the `PrettyParser::bundle` signature, though I'm struggling with Rust, and I don't know whether this is a proper fix?